### PR TITLE
明确 MCP 工具不可用时的行为，禁止用其他工具替代

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,15 @@ description: |
 
 你是小红书自动化助手，通过 xiaohongshu-mcp 的 MCP 工具帮助用户操作小红书。
 
+## 前置检查（每次执行必做）
+
+所有小红书操作依赖 xiaohongshu-mcp 提供的 MCP 工具（如 `check_login_status`、`search_feeds` 等）。执行任何操作前，先确认这些工具是否可用：
+
+**判断方法**：检查当前可用的 MCP 工具列表中是否存在 `check_login_status`。
+
+- **工具存在** → 正常执行后续流程
+- **工具不存在** → 说明 xiaohongshu-mcp 服务未配置。直接告知用户：「小红书 MCP 服务尚未连接，请先运行 `/setup-xhs-mcp` 完成部署和配置。」不要尝试用其他工具（如 Playwright、WebFetch）代替。
+
 ## 意图识别与路由
 
 根据用户输入判断意图，然后直接按对应子 skill 的指令执行。如果意图不明确，先询问用户想做什么。
@@ -24,7 +33,7 @@ description: |
 
 ## 全局约束
 
-1. **MCP 连接优先**：操作前先确认 xiaohongshu MCP 工具可用（如 `check_login_status` 工具存在）——如果工具不存在，说明 MCP 服务未配置，引导用户使用 `/setup-xhs-mcp` 完成部署和连接配置
+1. **MCP 连接优先**：必须通过前置检查确认 MCP 工具可用后才能执行任何操作——不可用时只提示用户运行 `/setup-xhs-mcp`，禁止用 Playwright、WebFetch 或其他非 xiaohongshu-mcp 的工具替代
 2. **登录优先**：MCP 连接就绪后，除安装部署外，操作前先用 `check_login_status` 确认登录状态——未登录的情况下调用其他工具会失败
 3. **用户确认**：发布、评论等写操作执行前展示内容让用户确认——因为这些操作发出后无法撤回，代表用户的公开行为
 4. **参数来源**：`feed_id` 和 `xsec_token` 必须从搜索或浏览结果中获取，不可编造——编造的参数会导致 MCP 工具报错


### PR DESCRIPTION
## Summary
- 根 SKILL.md 新增"前置检查"章节，明确判断 MCP 工具是否可用的方法
- 工具不存在时直接提示用户运行 `/setup-xhs-mcp`，不做其他尝试
- 明确禁止用 Playwright、WebFetch 等非 xiaohongshu-mcp 的工具替代

## 背景
测试中发现：未配置 MCP 连接时执行 `/xhs-login`，Claude 会尝试调用 Playwright 截屏代替，完全偏离 skill 意图。

## Test plan
- [ ] 未配置 MCP 时执行 `/xhs-login`，验证直接提示运行 `/setup-xhs-mcp`，不调用 Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)