### PR TITLE
修复 MCP 服务健康检测误判

### DIFF
--- a/skills/setup-xhs-mcp/SKILL.md
+++ b/skills/setup-xhs-mcp/SKILL.md
@@ -11,10 +11,10 @@ description: |
 
 ### 1. 检测服务状态
 
-检查 xiaohongshu-mcp 是否已在运行：
+检查 xiaohongshu-mcp 是否已在运行（注意：MCP 端点只接受 POST，GET 会返回 405，不能用 `-f` 判断）：
 
 ```bash
-curl -sf http://localhost:18060/mcp -o /dev/null && echo "running" || echo "not running"
+curl -so /dev/null http://localhost:18060/mcp && echo "running" || echo "not running"
 ```
 
 - 已运行 → 记录地址 `http://localhost:18060/mcp`，跳到步骤 3


### PR DESCRIPTION
## Summary
- curl 检测去掉 `-f` 参数，MCP 端点只接受 POST，GET 返回 405，`-f` 会把正在运行的服务误判为未运行

## 背景
测试发现 Go 二进制已在 :18060 运行，但 `curl -sf` 因收到 405 而返回失败，导致 setup 流程误认为服务未部署。

## Test plan
- [ ] 服务运行时执行 `/setup-xhs-mcp`，验证正确检测为 running

🤖 Generated with [Claude Code](https://claude.com/claude-code)